### PR TITLE
Expose optional image time-to-live

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ This project uses [Serverless](https://serverless.com) to manage deploy on AWS.
 
 ```bash
 # Install and Configure serverless (https://serverless.com/framework/docs/providers/aws/guide/credentials/)
-$ npm install serverless -g 
+$ npm install serverless -g
 
-$ sls deploy --region us-east-1 --bucket a-bucket-where-you-store-data
+$ sls deploy --region us-east-1 --bucket a-bucket-where-you-store-data --img-ttl 3600
 ```
 
 #### Docs
 
-See [/doc/API.md](/doc/API.md) for the documentation. 
+See [/doc/API.md](/doc/API.md) for the documentation.
 
 #### Live
 

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -494,6 +494,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<int:z>/<int:x>/<int:y>",
@@ -502,6 +503,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<int:z>/<int:x>/<int:y>@<int:scale>x.<ext>",
@@ -510,6 +512,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<int:z>/<int:x>/<int:y>@<int:scale>x",
@@ -518,6 +521,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>.<ext>",
@@ -526,6 +530,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>",
@@ -534,6 +539,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>@<int:scale>x.<ext>",
@@ -542,6 +548,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 @app.route(
     "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>@<int:scale>x",
@@ -550,6 +557,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    ttl=os.getenv("IMG_TTL"),
 )
 def _img(
     mosaicid: str = None,

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,7 @@ provider:
      Action:
        - "s3:GetObject"
        - "s3:HeadObject"
-     Resource:       
+     Resource:
        - "arn:aws:s3:::*"
 
 package:
@@ -49,6 +49,7 @@ functions:
       GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: YES
       GDAL_HTTP_MULTIPLEX: YES
       GDAL_HTTP_VERSION: 2
+      IMG_TTL: ${opt:img-ttl, ''}
       MAX_THREADS: 10
       MOSAIC_DEF_BUCKET: ${opt:bucket}
       PROJ_LIB: /opt/share/proj


### PR DESCRIPTION
Not sure if this PR interests you, feel free to not merge if not.

This just exposes `--img-ttl` in the `serverless.yml` config, which is read as an environment variable to be passed to `lambda-proxy`.