### PR TITLE
Update imports for rio-tiler v2

### DIFF
--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -19,9 +19,10 @@ from rasterio.transform import from_bounds
 from rio_color.utils import scale_dtype, to_math_type
 from rio_color.operations import parse_operations
 
-from rio_tiler.main import tile as cogeoTiler
-from rio_tiler.utils import array_to_image, get_colormap, linear_rescale
+from rio_tiler.colormap import get_colormap
+from rio_tiler.io.cogeo import tile as cogeoTiler
 from rio_tiler.profiles import img_profiles
+from rio_tiler.utils import render, linear_rescale
 
 from rio_tiler_mvt.mvt import encoder as mvtEncoder
 from rio_tiler_mosaic.mosaic import mosaic_tiler
@@ -627,7 +628,7 @@ def _img(
     return (
         "OK",
         f"image/{ext}",
-        array_to_image(rtile, mask, img_format=driver, color_map=color_map, **options),
+        render(rtile, mask, img_format=driver, color_map=color_map, **options),
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,13 @@ from setuptools import setup, find_packages
 
 
 # Runtime requirements.
-inst_reqs = ["cogeo-mosaic>=2.0.1", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
+inst_reqs = [
+    "cogeo-mosaic>=2.0.1",
+    "lambda-proxy~=5.0",
+    "rio-color",
+    "rio-tiler>=2.0a4",
+    "rio_tiler_mvt",
+]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "mock"],
     "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -1,4 +1,3 @@
-
 """tests cogeo_mosaic.custom_cmaps."""
 
 import pytest


### PR DESCRIPTION
Ref https://github.com/cogeotiff/rio-tiler/pull/154#issuecomment-602867145

At least with the image endpoint, just updating the imports seems to work on lambda. (I made my own `cogeo-layer` using `rio-tiler` v2 for testing).

I'll do testing on partial reads on a different branch

![image](https://user-images.githubusercontent.com/15164633/77374797-4663eb80-6d31-11ea-926c-7bf8554fd8ff.png)
