### PR TITLE
Cogeo mosaic backends

### DIFF
--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -362,16 +362,7 @@ def _wmts(
     binary_b64encode=True,
     tag=["tiles"],
 )
-@app.route(
-    "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>.pbf",
-    methods=["GET"],
-    cors=True,
-    payload_compression_method="gzip",
-    binary_b64encode=True,
-    tag=["tiles"],
-)
 def _mvt(
-    mosaicid: str = None,
     z: int = None,
     x: int = None,
     y: int = None,
@@ -382,12 +373,12 @@ def _mvt(
     resampling_method: str = "nearest",
 ) -> Tuple[str, str, BinaryIO]:
     """Handle MVT requests."""
-    if mosaicid:
-        url = _create_path(mosaicid)
-    elif url is None:
+    if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    assets = fetch_and_find_assets(url, x, y, z)
+    with auto_backend(url) as mosaic:
+        assets = mosaic.tile(x, y, z)
+
     if not assets:
         return ("EMPTY", "text/plain", f"No assets found for tile {z}-{x}-{y}")
 

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -152,21 +152,21 @@ def _create(
     binary_b64encode=True,
     tag=["mosaic"],
 )
-def _add(body: str, mosaicid: str = None) -> Tuple[str, str, str]:
+def _add(body: str, url: str, mosaicid: str = None) -> Tuple[str, str, str]:
     # TODO: Need validation
     mosaic_definition = json.loads(body)
 
-    if not mosaicid:
+    if not mosaicid and "{mosaicid}" in url:
         mosaicid = get_hash(body=body)
+        url = url.replace("{mosaicid}", mosaicid)
 
-    key = f"mosaics/{mosaicid}.json.gz"
-    bucket = os.environ["MOSAIC_DEF_BUCKET"]
-    _aws_put_data(key, bucket, _compress_gz_json(mosaic_definition), client=s3_client)
+    with auto_backend(url, mosaic_def=mosaic_definition) as mosaic:
+        mosaic.upload()
 
     return (
         "OK",
         "application/json",
-        json.dumps({"id": mosaicid, "url": f"s3://{bucket}/{key}"}),
+        json.dumps({"id": mosaicid, "url": url}),
     )
 
 

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -263,10 +263,7 @@ def _geojson(url: str = None) -> Tuple[str, str, str]:
     tag=["tiles"],
 )
 def _tilejson(
-    url: str = None,
-    tile_scale: int = 1,
-    tile_format: str = None,
-    **kwargs: Any,
+    url: str = None, tile_scale: int = 1, tile_format: str = None, **kwargs: Any,
 ) -> Tuple[str, str, str]:
     """Handle /tilejson.json requests."""
     if url is None:
@@ -282,7 +279,7 @@ def _tilejson(
         mosaic_def["minzoom"],
     ]
 
-    kwargs.update({'url': url})
+    kwargs.update({"url": url})
     host = app.host
 
     if tile_format in ["pbf", "mvt"]:
@@ -316,16 +313,7 @@ def _tilejson(
     binary_b64encode=True,
     tag=["tiles"],
 )
-@app.route(
-    "/<regex([0-9A-Fa-f]{56}):mosaicid>/wmts",
-    methods=["GET"],
-    cors=True,
-    payload_compression_method="gzip",
-    binary_b64encode=True,
-    tag=["tiles"],
-)
 def _wmts(
-    mosaicid: str = None,
     url: str = None,
     tile_format: str = "png",
     tile_scale: int = 1,
@@ -333,19 +321,18 @@ def _wmts(
     **kwargs: Any,
 ) -> Tuple[str, str, str]:
     """Handle /wmts requests."""
-    if mosaicid:
-        url = _create_path(mosaicid)
-    elif url is None:
+    if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
     if tile_scale is not None and isinstance(tile_scale, str):
         tile_scale = int(tile_scale)
 
-    mosaic_def = fetch_mosaic_definition(url)
+    with auto_backend(url) as mosaic:
+        mosaic_def = dict(mosaic.mosaic_def)
 
     kwargs.pop("SERVICE", None)
     kwargs.pop("REQUEST", None)
-    kwargs.update(dict(url=url))
+    kwargs.update({"url": url})
     query_string = urllib.parse.urlencode(list(kwargs.items()))
     query_string = query_string.replace(
         "&", "&amp;"

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -32,7 +32,7 @@ from cogeo_mosaic.utils import (
     create_mosaic,
     get_point_values,
 )
-from cogeo_mosaic.backends import auto_backend
+from cogeo_mosaic.backends import MosaicBackend
 
 from cogeo_mosaic_tiler import custom_methods
 from cogeo_mosaic_tiler.custom_cmaps import get_custom_cmap
@@ -98,7 +98,7 @@ def _create(
 
     # Load mosaic if it already exists
     try:
-        with auto_backend(url) as mosaic:
+        with MosaicBackend(url) as mosaic:
             mosaic_def = dict(mosaic.mosaic_def)
 
         return get_tilejson(mosaic_def, url, tile_scale, tile_format, **kwargs)
@@ -116,7 +116,7 @@ def _create(
             tile_cover_sort=tile_cover_sort,
         )
 
-    with auto_backend(url, mosaic_def=mosaic_def) as mosaic:
+    with MosaicBackend(url, mosaic_def=mosaic_def) as mosaic:
         mosaic.upload()
 
     return get_tilejson(mosaic_def, url, tile_scale, tile_format, **kwargs)
@@ -139,7 +139,7 @@ def _add(body: str, url: str, mosaicid: str = None) -> Tuple[str, str, str]:
         mosaicid = get_hash(body=body)
         url = url.replace("{mosaicid}", mosaicid)
 
-    with auto_backend(url, mosaic_def=mosaic_definition) as mosaic:
+    with MosaicBackend(url, mosaic_def=mosaic_definition) as mosaic:
         mosaic.upload()
 
     return (
@@ -162,7 +162,7 @@ def _info(url: str = None) -> Tuple[str, str, str]:
     if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         mosaic_def = dict(mosaic.mosaic_def)
 
     bounds = mosaic_def["bounds"]
@@ -214,7 +214,7 @@ def _geojson(url: str = None) -> Tuple[str, str, str]:
     if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         mosaic_def = dict(mosaic.mosaic_def)
 
     if not mosaic_def.get("tiles"):
@@ -246,7 +246,7 @@ def _tilejson(
     if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         mosaic_def = dict(mosaic.mosaic_def)
 
     return get_tilejson(mosaic_def, url, tile_scale, tile_format, **kwargs)
@@ -308,7 +308,7 @@ def _wmts(
     if tile_scale is not None and isinstance(tile_scale, str):
         tile_scale = int(tile_scale)
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         mosaic_def = dict(mosaic.mosaic_def)
 
     kwargs.pop("SERVICE", None)
@@ -357,7 +357,7 @@ def _mvt(
     if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         assets = mosaic.tile(x, y, z)
 
     if not assets:
@@ -480,7 +480,7 @@ def _img(
     if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         assets = mosaic.tile(x, y, z)
 
     if not assets:
@@ -565,7 +565,7 @@ def _point(
     if isinstance(lat, str):
         lat = float(lat)
 
-    with auto_backend(url) as mosaic:
+    with MosaicBackend(url) as mosaic:
         assets = mosaic.point(lng, lat)
 
     if not assets:

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -31,8 +31,6 @@ from cogeo_mosaic import version as mosaic_version
 from cogeo_mosaic.utils import (
     create_mosaic,
     fetch_mosaic_definition,
-    fetch_and_find_assets,
-    fetch_and_find_assets_point,
     get_point_values,
 )
 from cogeo_mosaic.backends import auto_backend

--- a/doc/API.md
+++ b/doc/API.md
@@ -19,7 +19,7 @@ For example:
 - HTTP:
     - `https://{endpoint-url}/{method}?url=http(s)://example.com/path/to/mosaic`
 - DynamoDB. If you don't pass a region, the local region is assumed. Note that if you don't pass a region you need _three_ `///`.
-    - `https://{endpoint-url}/{method}?url=dynamodb://{region}/{mosaicid}`
+    - `https://{endpoint-url}/{method}?url=dynamodb://{AWS region}/{mosaicid}`
     - `https://{endpoint-url}/{method}?url=dynamodb:///{mosaicid}`
 -  Local file. Note if you pass `file:///` you need _three_ `///`.
     - `https://{endpoint-url}/{method}?url=file:///path/to/local/file`

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,21 +1,39 @@
 # API
 
-Online API documentation can be found over `{endpoint}/docs`.
+Online API documentation can be found at `{endpoint}/docs`.
 
 ## mosaicJSON path
 
-The cogeo-mosaic-tiler support two ways of passing the mosaicJSON path.
-- `https://{endpoint-url}/{method}?url={mosaicURL}` 
+Every method to `cogeo-mosaic-tiler` accepts a `url` parameter, which allows for
+describing the path to the MosaicJSON, and further allows using different
+backends, such as an internet URL over HTTP, a file on S3, or a DynamoDB table.
 
-The **mosaicURL** can be any web hosted files.
+```
+https://{endpoint-url}/{method}?url={mosaicURL}
+```
 
-- `https://{endpoint-url}/{mosaicid}/{method}` (advanced method)
+For example:
 
-The **mosaicid** should be a string matching `[0-9A-Fa-f]{56}` regex (usually created using `sha224sum mymosaic.json.gz`). When using mosaicid, the tiler will reconscruct a file s3 url and then result to `s3://{my-bucket}/mosaics/mosaicid.json.gz`
+- S3:
+    - `https://{endpoint-url}/{method}?url=s3://{bucket}/{key}`
+- HTTP:
+    - `https://{endpoint-url}/{method}?url=http(s)://example.com/path/to/mosaic`
+- DynamoDB. If you don't pass a region, the local region is assumed. Note that if you don't pass a region you need _three_ `///`.
+    - `https://{endpoint-url}/{method}?url=dynamodb://{region}/{mosaicid}`
+    - `https://{endpoint-url}/{method}?url=dynamodb:///{mosaicid}`
+-  Local file. Note if you pass `file:///` you need _three_ `///`.
+    - `https://{endpoint-url}/{method}?url=file:///path/to/local/file`
+    - `https://{endpoint-url}/{method}?url=/path/to/local/file`
+    - `https://{endpoint-url}/{method}?url=./relative/path/to/local/file`
+    - `https://{endpoint-url}/{method}?url=relative/path/to/local/file`
+
+Historically, a  **`mosaicid`** is a 56-character hexadecimal string (matching `[0-9A-Fa-f]{56}` regex), usually created using `sha224sum mymosaic.json.gz`.
+
+<!-- When using mosaicid, the tiler will reconscruct a file s3 url and then result to `s3://{my-bucket}/mosaics/mosaicid.json.gz` -->
 
 ```
 $ cogeo-mosaic create mylist.txt -o mosaic.json
-$ cat mosaic.json | gzip > mosaic.json.gz 
+$ cat mosaic.json | gzip > mosaic.json.gz
 
 $ sha224sum mosaic.json.gz
 92979ccd7d443ff826e493e4af707220ba77f16def6f15db86141ba8  mosaic.json.gz
@@ -35,13 +53,13 @@ $ curl https://{endpoint-url}/92979ccd7d443ff826e493e4af707220ba77f16def6f15db86
   - format: **json**
 - returns: mosaic definition (application/json, compression: **gzip**)
 
-Note: equivalent of running `cogeo-mosaic create` locally 
+Note: equivalent of running `cogeo-mosaic create` locally
 
 ```bash
 $ curl -X POST -d @list.json https://{endpoint-url}/create`
 ```
 
-## - Add MosaicJSON 
+## - Add MosaicJSON
 `/add`
 
 - methods:POST
@@ -60,27 +78,18 @@ $ curl -X POST -d @list.json https://{endpoint-url}/add`
 ```
 
 ## - Mosaic Metadata
+
 `/info`
+
 - methods: GET
 - **url** (in querytring): mosaic definition url
 - returns: mosaic defintion info (application/json, compression: **gzip**)
 
 ```bash
-$ curl https://{endpoint-url}/info?url=https://my-mosaic.json.gz
+$ curl https://{endpoint-url}/info?url=s3://my_bucket/my_mosaic.json.gz
 ```
 
-`/<mosaicid>/info`
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- returns: mosaic defintion info (application/json, compression: **gzip**)
-
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/info
-```
-
-```json
+```js
 {
     "bounds": [],                // mosaic bounds
     "center": [lon, lat, zoom],     // mosaic center
@@ -95,25 +104,16 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 ## - Mosaic GeoJSON
 
 `/geojson`
+
 - methods: GET
 - **url** (in querytring): mosaic definition url
 - returns: mosaic-json as geojson (application/json, compression: **gzip**)
 
 ```bash
-$ curl https://{endpoint-url}/geojson?url=s3://my_file.json.gz
+$ curl https://{endpoint-url}/geojson?url=s3://my_bucket/my_mosaic.json.gz
 ```
 
-`/<mosaicid>/geojson`
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- returns: mosaic-json as geojson (application/json, compression: **gzip**)
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/geojson
-```
-
-```json
+```js
 {
     "type":"FeatureCollection",
     "features":[
@@ -149,21 +149,7 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 - returns: tileJSON defintion (application/json, compression: **gzip**)
 
 ```bash
-$ curl https://{endpoint-url}/tilejson.json?url=s3://my_file.json.gz
-```
-
-`/<mosaicid>/tilejson.json`
-
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- **tile_format** (optional, str): output tile format (default: "png")
-- **tile_scale** (optional, int): output tile scale (default: 1 = 256px)
-- **kwargs** (in querytring): tiler options
-- returns: tileJSON defintion (application/json, compression: **gzip**)
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/tilejson.json
+$ curl https://{endpoint-url}/tilejson.json?url=s3://my_bucket/my_mosaic.json.gz
 ```
 
 ```json
@@ -172,7 +158,7 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
     "center": [lon, lat, minzoom],
     "maxzoom": 22,
     "minzoom": 18,
-    "name": "s3://my_file.json.gz",
+    "name": "s3://my_bucket/my_mosaic.json.gz",
     "tilejson": "2.1.0",
     "tiles": [
         "https://{endpoint-url}/{{z}}/{{x}}/{{y}}@2x.<ext>"
@@ -193,23 +179,9 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 - returns: WMTS xml (application/xml, compression: **gzip**)
 
 ```bash
-$ curl https://{endpoint-url}/wmts?url=s3://my_file.json.gz)
+$ curl https://{endpoint-url}/wmts?url=s3://my_bucket/my_mosaic.json.gz
 ```
 
-`/<mosaicid>/wmts`
-
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- **tile_format** (optional, str): output tile format (default: "png")
-- **tile_scale** (optional, int): output tile scale (default: 1 = 256px)
-- **title** (optional, str): layer name (default: "Cloud Optimizied GeoTIFF Mosaic")
-- **kwargs** (in querytring): tiler options
-- returns: WMTS xml (application/xml, compression: **gzip**)
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/wmts
-```
 <details>
 
 ```xml
@@ -314,10 +286,10 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 ```
 </details>
 
-## - image tiles
-`/<int:z>/<int:x>/<int:y>.<ext>`
+## - Image tiles
 
-`/<int:z>/<int:x>/<int:y>@2x.<ext>`
+- `/<int:z>/<int:x>/<int:y>.<ext>`
+- `/<int:z>/<int:x>/<int:y>@2x.<ext>`
 
 - methods: GET
 - **z**: Mercator tile zoom value
@@ -336,35 +308,14 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 - returns: image body (image/jpeg)
 
 ```bash
-$ curl https://{endpoint-url}/8/32/22.png?url=s3://my_file.json.gz&indexes=1,2,3&rescale=100,3000&color_ops=Gamma RGB 3&pixel_selection=first
-```
-
-`/<mosaicid>/<int:z>/<int:x>/<int:y>.<ext>`
-
-`/<mosaicid>/<int:z>/<int:x>/<int:y>@2x.<ext>`
-
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- **z**: Mercator tile zoom value
-- **x**: Mercator tile x value
-- **y**: Mercator tile y value
-- **scale**: Tile scale (default: 1)
-- **ext**: Output tile format (e.g `jpg`)
-- **indexes** (optional, str): dataset band indexes (default: None)
-- **rescale** (optional, str): min/max for data rescaling (default: None)
-- **color_ops** (optional, str): rio-color formula (default: None)
-- **color_map** (optional, str): rio-tiler colormap (default: None)
-- **pixel_selection** (optional, str): mosaic pixel selection (default: `first`)
-- **resampling_method** (optional, str): tiler resampling method (default: `nearest`)
-- compression: **gzip**
-- returns: image body (image/jpeg)
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/8/32/22.png?indexes=1,2,3&rescale=100,3000&color_ops=Gamma RGB 3&pixel_selection=first
+$ curl https://{endpoint-url}/8/32/22.png?url=s3://my_bucket/my_mosaic.json.gz&indexes=1,2,3&rescale=100,3000&color_ops=Gamma RGB 3&pixel_selection=first
 ```
 
 ## - Vector tiles
+
+Note that generating vector tiles depends on the optional dependency
+`rio-tiler-mvt`. If the vector tile endpoint is requested and the dependency is
+not installed, an error will be raised.
 
 `/<int:z>/<int:x>/<int:y>.<pbf>`
 
@@ -382,28 +333,8 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 - returns: tile body (application/x-protobuf)
 
 ```bash
-$ curl https://{endpoint-url}/8/32/22.pbf?url=s3://my_file.json.gz&pixel_selection=first
+$ curl https://{endpoint-url}/8/32/22.pbf?url=s3://my_bucket/my_mosaic.json.gz&pixel_selection=first
 ```
-
-`/<mosaicid>/<int:z>/<int:x>/<int:y>.<pbf>`
-
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- **z**: Mercator tile zoom value
-- **x**: Mercator tile x value
-- **y**: Mercator tile y value
-- **tile_size**: (optional, int) Tile size (default: 256)
-- **pixel_selection** (optional, str): mosaic pixel selection (default: `first`)
-- **feature_type** (optional, str): feature type (default: `point`)
-- **resampling_method** (optional, str): tiler resampling method (default: `nearest`)
-- compression: **gzip**
-- returns: tile body (application/x-protobuf)
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/8/32/22.pbf?pixel_selection=first
-```
-
 
 ### - Point Value
 
@@ -417,20 +348,5 @@ $ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
 - returns: json(application/json, compression: **gzip**)
 
 ```bash
-$ curl https://{endpoint-url}/point?url=s3://my_file.json.gz&lng=10&lat=-10
+$ curl https://{endpoint-url}/point?url=s3://my_bucket/my_mosaic.json.gz&lng=10&lat=-10
 ```
-
-`/<mosaicid>/point`
-
-- methods: GET
-- **mosaicid** (in path): mosaic definition id
-- **lng** (required, float): longitude
-- **lat** (required, float): lattitude
-- compression: **gzip**
-- returns: tile body (application/x-protobuf)
-
-```bash
-$ curl https://{endpoint-url}/0505ad234b5fb97df134001709b8a42eddce5d
-03b200eb8f7f4540d6/point?lng=10&lat=-10
-```
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 # Runtime requirements.
 inst_reqs = [
-    "cogeo-mosaic @ git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc#egg=cogeo-mosaic",
+    "cogeo-mosaic @ git+https://github.com/developmentseed/cogeo-mosaic@vsEdits#egg=cogeo-mosaic",
     "rio-color",
     "rio_tiler_mvt",
     "lambda-proxy~=5.0",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@ from setuptools import setup, find_packages
 
 
 # Runtime requirements.
-inst_reqs = ["git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
+inst_reqs = [
+    "git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc",
+    "rio-color",
+    "rio_tiler_mvt",
+    "lambda-proxy~=5.0",
+]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "mock"],
     "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 # Runtime requirements.
 inst_reqs = [
-    "git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc",
+    "cogeo-mosaic @ git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc#egg=cogeo-mosaic",
     "rio-color",
     "rio_tiler_mvt",
     "lambda-proxy~=5.0",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 # Runtime requirements.
-inst_reqs = ["cogeo-mosaic>=2.0.1", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
+inst_reqs = ["git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "mock"],
     "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -1,4 +1,3 @@
-
 """tests cogeo_mosaic.custom_cmaps."""
 
 import pytest


### PR DESCRIPTION
Use mosaic backends, under development in https://github.com/developmentseed/cogeo-mosaic/pull/38

cc @vincentsarago @geospatial-jeff

- Removes the plain `/mosaicid/endpoint` type. We could add a `mosaicid://[0-9a-f]{n}` backend in `auto_backend` if that's desired
- Requires a `url` for all methods. 
- For `create` and `add` endpoints, the url accepts a `{mosaicid}` as part of the url string, which will be replaced with the `mosaicid` of the generated mosaic definition

Questions

- Is `aws_session` still important to pass to `rasterio`? So that fetching assets happens with the same session?
- How to pass specialized arguments to an automatically-chosen backend? I.e. if you want to use the same AWS `client` for interacting with S3, you might want to pass `client` to `auto_backend` but only used if the url points to `s3`...

	Though right now passing `client` is the only edge case I see. I currently allow forcing the `dynamodb` region using the `netloc` part of the path. I.e.

	```
	dynamodb://us-west-2/mosaicid
	``` 

	forces the driver to load from `us-west-2`, whereas

	```
	dynamodb:///mosaicid
	```
	would allow the driver to choose the right region, which currently defaults to loaded from an env variable, and then defaulting to `us-east-1`.