### PR TITLE
Update to use geo-layer lambda layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambgeo/lambda:gdal2.4-py3.7
+FROM lambgeo/lambda:gdal2.4-py3.7-geolayer
 
 WORKDIR /tmp
 
@@ -8,6 +8,5 @@ COPY cogeo_mosaic_tiler/ cogeo_mosaic_tiler/
 COPY setup.py setup.py
 
 # Install dependencies
-RUN pip install cython==0.28 --no-cache-dir
 RUN pip install . --user
 RUN rm -rf cogeo_mosaic_tiler setup.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM remotepixel/amazonlinux:gdal2.4-py3.7-cogeo
+FROM lambgeo/lambda:gdal2.4-py3.7
 
 WORKDIR /tmp
 
@@ -8,5 +8,6 @@ COPY cogeo_mosaic_tiler/ cogeo_mosaic_tiler/
 COPY setup.py setup.py
 
 # Install dependencies
+RUN pip install cython==0.28 --no-cache-dir
 RUN pip install . --user
 RUN rm -rf cogeo_mosaic_tiler setup.py

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,7 +30,7 @@ provider:
      Action:
        - "s3:GetObject"
        - "s3:HeadObject"
-     Resource:       
+     Resource:
        - "arn:aws:s3:::*"
 
 package:
@@ -42,7 +42,7 @@ functions:
     memorySize: 2048
     timeout: 10
     layers:
-      - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-cogeo:6
+      - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-geo:1
     environment:
       CPL_TMPDIR: /tmp
       GDAL_CACHEMAX: 25%

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 # Runtime requirements.
 inst_reqs = [
     "cogeo-mosaic>=2.0.1",
-    "lambda-proxy~=5.0",
+    "lambda-proxy~=5.2",
     "requests",
     "rio-cogeo",
     "rio-color",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,16 @@ from setuptools import setup, find_packages
 
 
 # Runtime requirements.
-inst_reqs = ["cogeo-mosaic>=2.0.1", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
+inst_reqs = [
+    "cogeo-mosaic>=2.0.1",
+    "lambda-proxy~=5.0",
+    "requests",
+    "rio-cogeo",
+    "rio-color",
+    "rio-tiler",
+    "rio_tiler_mosaic",
+    "rio_tiler_mvt",
+]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "mock"],
     "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -1,4 +1,3 @@
-
 """tests cogeo_mosaic.custom_cmaps."""
 
 import pytest


### PR DESCRIPTION
Updates the install requirements to include necessary packages that `geo-layer` leaves out.

Also bumps `lambda-proxy` to 5.2. Let me know if that's a problem.

I had to install `cython` locally in order for `vtzero` to build correctly.