### PR TITLE
Use HTTP API instead of REST API for API Gateway

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -30,7 +30,7 @@ provider:
      Action:
        - "s3:GetObject"
        - "s3:HeadObject"
-     Resource:       
+     Resource:
        - "arn:aws:s3:::*"
 
 package:
@@ -58,7 +58,7 @@ functions:
       VSI_CACHE: TRUE
       VSI_CACHE_SIZE: 536870912
     events:
-      - http:
+      - httpApi:
           path: /{proxy+}
-          method: any
+          method: '*'
           cors: true


### PR DESCRIPTION
Now that lambda proxy has full support for using API Gateway's HTTP API, there's really no reason not to default to it, especially since the default `serverless.yml` doesn't have any auth in the API Gateway configuration. The HTTP API is faster and cheaper.

Closes #1 
(Isn't that funny how the numbering is now up to `#13` and I did most of that 😅)