### PR TITLE
Add cache-control header option through serverless.yml

### DIFF
--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -362,16 +362,7 @@ def _wmts(
     binary_b64encode=True,
     tag=["tiles"],
 )
-@app.route(
-    "/<regex([0-9A-Fa-f]{56}):mosaicid>/<int:z>/<int:x>/<int:y>.pbf",
-    methods=["GET"],
-    cors=True,
-    payload_compression_method="gzip",
-    binary_b64encode=True,
-    tag=["tiles"],
-)
 def _mvt(
-    mosaicid: str = None,
     z: int = None,
     x: int = None,
     y: int = None,
@@ -382,12 +373,12 @@ def _mvt(
     resampling_method: str = "nearest",
 ) -> Tuple[str, str, BinaryIO]:
     """Handle MVT requests."""
-    if mosaicid:
-        url = _create_path(mosaicid)
-    elif url is None:
+    if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
-    assets = fetch_and_find_assets(url, x, y, z)
+    with auto_backend(url) as mosaic:
+        assets = mosaic.tile(x, y, z)
+
     if not assets:
         return ("EMPTY", "text/plain", f"No assets found for tile {z}-{x}-{y}")
 

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -152,21 +152,21 @@ def _create(
     binary_b64encode=True,
     tag=["mosaic"],
 )
-def _add(body: str, mosaicid: str = None) -> Tuple[str, str, str]:
+def _add(body: str, url: str, mosaicid: str = None) -> Tuple[str, str, str]:
     # TODO: Need validation
     mosaic_definition = json.loads(body)
 
-    if not mosaicid:
+    if not mosaicid and "{mosaicid}" in url:
         mosaicid = get_hash(body=body)
+        url = url.replace("{mosaicid}", mosaicid)
 
-    key = f"mosaics/{mosaicid}.json.gz"
-    bucket = os.environ["MOSAIC_DEF_BUCKET"]
-    _aws_put_data(key, bucket, _compress_gz_json(mosaic_definition), client=s3_client)
+    with auto_backend(url, mosaic_def=mosaic_definition) as mosaic:
+        mosaic.upload()
 
     return (
         "OK",
         "application/json",
-        json.dumps({"id": mosaicid, "url": f"s3://{bucket}/{key}"}),
+        json.dumps({"id": mosaicid, "url": url}),
     )
 
 

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -263,10 +263,7 @@ def _geojson(url: str = None) -> Tuple[str, str, str]:
     tag=["tiles"],
 )
 def _tilejson(
-    url: str = None,
-    tile_scale: int = 1,
-    tile_format: str = None,
-    **kwargs: Any,
+    url: str = None, tile_scale: int = 1, tile_format: str = None, **kwargs: Any,
 ) -> Tuple[str, str, str]:
     """Handle /tilejson.json requests."""
     if url is None:
@@ -282,7 +279,7 @@ def _tilejson(
         mosaic_def["minzoom"],
     ]
 
-    kwargs.update({'url': url})
+    kwargs.update({"url": url})
     host = app.host
 
     if tile_format in ["pbf", "mvt"]:
@@ -316,16 +313,7 @@ def _tilejson(
     binary_b64encode=True,
     tag=["tiles"],
 )
-@app.route(
-    "/<regex([0-9A-Fa-f]{56}):mosaicid>/wmts",
-    methods=["GET"],
-    cors=True,
-    payload_compression_method="gzip",
-    binary_b64encode=True,
-    tag=["tiles"],
-)
 def _wmts(
-    mosaicid: str = None,
     url: str = None,
     tile_format: str = "png",
     tile_scale: int = 1,
@@ -333,19 +321,18 @@ def _wmts(
     **kwargs: Any,
 ) -> Tuple[str, str, str]:
     """Handle /wmts requests."""
-    if mosaicid:
-        url = _create_path(mosaicid)
-    elif url is None:
+    if url is None:
         return ("NOK", "text/plain", "Missing 'URL' parameter")
 
     if tile_scale is not None and isinstance(tile_scale, str):
         tile_scale = int(tile_scale)
 
-    mosaic_def = fetch_mosaic_definition(url)
+    with auto_backend(url) as mosaic:
+        mosaic_def = dict(mosaic.mosaic_def)
 
     kwargs.pop("SERVICE", None)
     kwargs.pop("REQUEST", None)
-    kwargs.update(dict(url=url))
+    kwargs.update({"url": url})
     query_string = urllib.parse.urlencode(list(kwargs.items()))
     query_string = query_string.replace(
         "&", "&amp;"

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -156,6 +156,7 @@ def _add(body: str, url: str, mosaicid: str = None) -> Tuple[str, str, str]:
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["metadata"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _info(url: str = None) -> Tuple[str, str, str]:
     """Handle /info requests."""
@@ -208,6 +209,7 @@ def _info(url: str = None) -> Tuple[str, str, str]:
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["metadata"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _geojson(url: str = None) -> Tuple[str, str, str]:
     """Handle /geojson requests."""
@@ -238,6 +240,7 @@ def _geojson(url: str = None) -> Tuple[str, str, str]:
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _tilejson(
     url: str = None, tile_scale: int = 1, tile_format: str = None, **kwargs: Any,
@@ -293,6 +296,7 @@ def get_tilejson(mosaic_def, url, tile_scale, tile_format, **kwargs):
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _wmts(
     url: str = None,
@@ -342,6 +346,7 @@ def _wmts(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _mvt(
     z: int = None,
@@ -437,6 +442,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 @app.route(
     "/<int:z>/<int:x>/<int:y>",
@@ -445,6 +451,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 @app.route(
     "/<int:z>/<int:x>/<int:y>@<int:scale>x.<ext>",
@@ -453,6 +460,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 @app.route(
     "/<int:z>/<int:x>/<int:y>@<int:scale>x",
@@ -461,6 +469,7 @@ def _postprocess(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _img(
     z: int = None,
@@ -548,6 +557,7 @@ def _img(
     payload_compression_method="gzip",
     binary_b64encode=True,
     tag=["tiles"],
+    cache_control=os.getenv("CACHE_CONTROL", None),
 )
 def _point(
     lng: float = None, lat: float = None, url: str = None

--- a/cogeo_mosaic_tiler/handlers/app.py
+++ b/cogeo_mosaic_tiler/handlers/app.py
@@ -31,8 +31,6 @@ from cogeo_mosaic import version as mosaic_version
 from cogeo_mosaic.utils import (
     create_mosaic,
     fetch_mosaic_definition,
-    fetch_and_find_assets,
-    fetch_and_find_assets_point,
     get_point_values,
 )
 from cogeo_mosaic.backends import auto_backend

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,7 +30,7 @@ provider:
      Action:
        - "s3:GetObject"
        - "s3:HeadObject"
-     Resource:       
+     Resource:
        - "arn:aws:s3:::*"
 
 package:
@@ -44,6 +44,7 @@ functions:
     layers:
       - arn:aws:lambda:${self:provider.region}:524387336408:layer:gdal24-py37-cogeo:6
     environment:
+      CACHE_CONTROL: ${opt:cache-control, 'max-age=3600'}
       CPL_TMPDIR: /tmp
       GDAL_CACHEMAX: 25%
       GDAL_DATA: /opt/share/gdal

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@ from setuptools import setup, find_packages
 
 
 # Runtime requirements.
-inst_reqs = ["git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
+inst_reqs = [
+    "git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc",
+    "rio-color",
+    "rio_tiler_mvt",
+    "lambda-proxy~=5.0",
+]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "mock"],
     "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 # Runtime requirements.
-inst_reqs = ["cogeo-mosaic>=2.0.1", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
+inst_reqs = ["git+https://github.com/kylebarron/cogeo-mosaic@mosaic-abc", "rio-color", "rio_tiler_mvt", "lambda-proxy~=5.0"]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "mock"],
     "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -1,4 +1,3 @@
-
 """tests cogeo_mosaic.custom_cmaps."""
 
 import pytest


### PR DESCRIPTION
I wrote this on top of #10 , so would be merged after.

This adds a user-provided Cache-Control header to all `GET` methods.